### PR TITLE
Fix bug with multiple nodes + Access Door stop autopolling + add nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,50 @@
-# node-red-contrib-unifi
+# node-red-contrib-unifi-client
 
-start project .
+This project add some nodes to node-red, to interact with unifi from [ubiquiti](https://ui.com) .
 
-WIP for access integration
+This project, is mainly a proof of concept of the library [unifi-client](https://github.com/thib3113/unifi-client), and so mainly reuse tested functions .
 
+You can read nodes documentation [here](https://github.com/thib3113/node-red-contrib-unifi-client/wiki) .
 
-Doesn't hesitate to participate
+## Requirements
+- Installed UniFi-Controller version v6 or newer
+- An unifi user, without 2FA*
+
+*: 2FA is supported, but not adapted to automated usage .
+
+## Installation recommended
+The recommended way to install this module is from the Node-RED GUI itself.
+Menu/manage palette/Install/search for unifi and then click install.
+
+## Main Nodes
+
+### unifi-raw-controller-request
+Allow you to do all the request you want to unifi . The node will do the connection and other for you, and then return directly the result of the request in msg.payload
+
+### unifi-door-events
+Check for events on Unifi access Doors, and send a message per event .
+
+Can be used to trigger a workflow depending on who open the door .
+
+### unifi-access-unlock-relais
+Ask to unlock a relais (doors for example)
+
+## Developpers / Contributing
+Adding nodes to this library is pretty easy .
+
+First of all, be sure to have a ready node-red environnement (follow install tutorial), then clone the repos and install it in node-red config directory with a local module `npm i /home/thib3113/repo/` .
+
+Then, you can create a new node, you can check the example of `DoorEvents` :
+```
+- create a ts file in src/nodes
+  - create a classe extending Node
+  - export a function that will call the function "registerNode"
+- create an html file with the same name as the ts file (without the extension)
+- configure the package.json node-red part to add your node
+```
+
+To do request to Unifi, feel free to read the documentation of [unifi-client](https://thib3113.github.io/unifi-client/) .
+
+When you are ready, open a PR
+
+Thank you

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "nodes": {
       "controller-config": "build/nodes/Controller.js",
       "door-events": "build/nodes/DoorEvents.js",
-      "unifi-raw-controller-request": "build/nodes/RawControllerRequest.js"
+      "unifi-raw-controller-request": "build/nodes/RawControllerRequest.js",
+      "unifi-get-access-devices": "build/nodes/GetAccessDevices.js",
+      "unifi-access-unlock-relais": "build/nodes/UnlockRelais.js"
     }
   },
   "repository": {

--- a/public/GetAccessDevices.html
+++ b/public/GetAccessDevices.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    RED.nodes.registerType('unifi-door-events', {
+    RED.nodes.registerType('unifi-get-access-devices', {
         category: 'UniFiAccess',
         defaults: {
             name: {
@@ -16,9 +16,9 @@
         outputs: 1,
         icon: 'unifi.png',
         color: '#159eda',
-        paletteLabel: 'Door Events',
+        paletteLabel: 'Get Access Devices',
         label: function () {
-            return this.name || 'unifi-door-events';
+            return this.name || 'unifi-get-access-devices';
         },
         labelStyle: function () {
             return this.name ? 'node_label_italic' : '';
@@ -30,10 +30,10 @@
                     type: "POST",
                     contentType: "application/json; charset=utf-8",
                     success: function (resp) {
-                        RED.notify('polling of door events sent');
+                        RED.notify('start getting devices');
                     },
                     error: function (jqXHR, textStatus, errorThrown) {
-                        RED.notify('fail to poll door events');
+                        RED.notify('fail to send request');
                     }
                 });
             }
@@ -41,7 +41,7 @@
     });
 </script>
 
-<script data-template-name="unifi-door-events" type="text/html">
+<script data-template-name="unifi-get-access-devices" type="text/html">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name" />
@@ -54,7 +54,7 @@
     </div>
 </script>
 
-<script data-help-name="unifi-door-events" type="text/markdown">
+<script data-help-name="unifi-get-access-devices" type="text/markdown">
 Receive events from Unifi access Doors
 
 ### Inputs

--- a/public/GetAccessDevices.html
+++ b/public/GetAccessDevices.html
@@ -55,45 +55,5 @@
 </script>
 
 <script data-help-name="unifi-get-access-devices" type="text/markdown">
-Receive events from Unifi access Doors
-
-### Inputs
-
-Use an inject with a repeat option, each call (or click on the button) will check for events
-
-: until (number)        :  A ms timestamp describing until when you want events
-
-### Outputs
-
-1. Standard output
-: payload.door (object) : Object containing door informations (use debug)
-: payload.door.user_id (string) : the user_id
-: payload.door.name (string) : the name
-: payload.door.first_name (string) : the first_name
-: payload.door.last_name (string) : the last_name
-: payload.door.door (string) : the door
-: payload.door.door_id (string) : the door_id
-: payload.door.door_type (string) : the door_type
-: payload.door.location (string) : the location
-: payload.door.location_id (string) : the location_id
-: payload.door.location_type (string) : the location_type
-: payload.door.door_entry_method (string) : the door_entry_method
-: payload.door.credential_provider (string) : the credential_provider
-: payload.door.event_time (number) : the timestamp (seconds) for this event
-: payload.door.result (string) : the result of this event
-: payload.door.resource_id (string) : the resource_id
-
-
-
-
-
-
-### Details
-
-This node is used to get Doors events from Unifi Access . Each events  from"until" (or last poll), will produce one message, per event .
-Feel free to do somethings with it .
-
-### References
-
-not for the moment
+TODO : write a documentation
 </script>

--- a/public/RawControllerRequest.html
+++ b/public/RawControllerRequest.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     RED.nodes.registerType('unifi-raw-controller-request', {
-        category: 'UniFi',
+        category: 'UniFiDebug',
         defaults: {
             name: {
                 value: '',

--- a/public/UnlockRelais.html
+++ b/public/UnlockRelais.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    RED.nodes.registerType('unifi-door-events', {
+    RED.nodes.registerType('unifi-access-unlock-relais', {
         category: 'UniFiAccess',
         defaults: {
             name: {
@@ -10,15 +10,19 @@
                 value: '',
                 type: 'unifi-controller',
                 required: true
+            },
+            deviceId: {
+                value: '',
+                required: true
             }
         },
         inputs: 1,
-        outputs: 1,
+        outputs: 0,
         icon: 'unifi.png',
         color: '#159eda',
-        paletteLabel: 'Door Events',
+        paletteLabel: 'Unlock Relais',
         label: function () {
-            return this.name || 'unifi-door-events';
+            return this.name || 'unifi-access-unlock-relais';
         },
         labelStyle: function () {
             return this.name ? 'node_label_italic' : '';
@@ -30,10 +34,10 @@
                     type: "POST",
                     contentType: "application/json; charset=utf-8",
                     success: function (resp) {
-                        RED.notify('polling of door events sent');
+                        RED.notify('start getting devices');
                     },
                     error: function (jqXHR, textStatus, errorThrown) {
-                        RED.notify('fail to poll door events');
+                        RED.notify('fail to send request');
                     }
                 });
             }
@@ -41,7 +45,7 @@
     });
 </script>
 
-<script data-template-name="unifi-door-events" type="text/html">
+<script data-template-name="unifi-access-unlock-relais" type="text/html">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name" />
@@ -52,9 +56,13 @@
             <option value="">Choose...</option>
         </select>
     </div>
+    <div class="form-row">
+        <label for="node-input-deviceId"><i class="fa fa-tag"></i> DeviceId</label>
+        <input type="text" id="node-input-deviceId" placeholder="DeviceId" />
+    </div>
 </script>
 
-<script data-help-name="unifi-door-events" type="text/markdown">
+<script data-help-name="unifi-access-unlock-relais" type="text/markdown">
 Receive events from Unifi access Doors
 
 ### Inputs

--- a/public/UnlockRelais.html
+++ b/public/UnlockRelais.html
@@ -63,45 +63,5 @@
 </script>
 
 <script data-help-name="unifi-access-unlock-relais" type="text/markdown">
-Receive events from Unifi access Doors
-
-### Inputs
-
-Use an inject with a repeat option, each call (or click on the button) will check for events
-
-: until (number)        :  A ms timestamp describing until when you want events
-
-### Outputs
-
-1. Standard output
-: payload.door (object) : Object containing door informations (use debug)
-: payload.door.user_id (string) : the user_id
-: payload.door.name (string) : the name
-: payload.door.first_name (string) : the first_name
-: payload.door.last_name (string) : the last_name
-: payload.door.door (string) : the door
-: payload.door.door_id (string) : the door_id
-: payload.door.door_type (string) : the door_type
-: payload.door.location (string) : the location
-: payload.door.location_id (string) : the location_id
-: payload.door.location_type (string) : the location_type
-: payload.door.door_entry_method (string) : the door_entry_method
-: payload.door.credential_provider (string) : the credential_provider
-: payload.door.event_time (number) : the timestamp (seconds) for this event
-: payload.door.result (string) : the result of this event
-: payload.door.resource_id (string) : the resource_id
-
-
-
-
-
-
-### Details
-
-This node is used to get Doors events from Unifi Access . Each events  from"until" (or last poll), will produce one message, per event .
-Feel free to do somethings with it .
-
-### References
-
-not for the moment
+    TODO : write a documentation
 </script>

--- a/src/lib/TechnicalNode.ts
+++ b/src/lib/TechnicalNode.ts
@@ -4,8 +4,7 @@ import * as RED from 'node-red';
 export class TechnicalNode<
     TNode extends REDRegistry.Node<TCredentials> = any,
     TNodeDefinition extends REDRegistry.NodeDef = any,
-    TCredentials = any,
-    TSettings = any
+    TCredentials = any
 > {
     protected get definition(): TNodeDefinition {
         if (!this._definition) {
@@ -27,47 +26,12 @@ export class TechnicalNode<
     constructor(readonly nodeRED: RED.NodeAPI) {}
 
     //arrow function for binding
-    private nodeConstructor = (
-        node: TNode,
-        definition: TNodeDefinition,
-        construct: (node: TNode, definition: TNodeDefinition) => void = () => {}
-    ): void => {
+    public nodeConstructor = (node: TNode, definition: TNodeDefinition): void => {
         this._node = node;
         this._definition = definition;
         this.nodeRED.nodes.createNode(node, definition);
-        construct(node, definition);
+        this.init();
     };
 
-    /**
-     * Registers a node constructor
-     * @param type - the string type name
-     * @param construct - the constructor function for this node type
-     * @param opts - optional additional options for the node
-     * @param postConstructFn - a function, called after each construc
-     */
-    public init(
-        type: string,
-        construct?: (node: TNode, definition: TNodeDefinition) => void,
-        opts?: {
-            credentials?: REDRegistry.NodeCredentials<TCredentials>;
-            settings?: REDRegistry.NodeSettings<TSettings>; // tslint:disable-line:no-unnecessary-generics
-        },
-        postConstructFn?: () => void
-    ): void {
-        const self = this;
-        this.nodeRED.nodes.registerType(
-            type,
-            function (this: TNode, definition: TNodeDefinition) {
-                try {
-                    self.nodeConstructor(this, definition, construct);
-                    if (postConstructFn) {
-                        postConstructFn();
-                    }
-                } catch (e) {
-                    this.error(e);
-                }
-            },
-            opts
-        );
-    }
+    protected async init(): Promise<void> {}
 }

--- a/src/lib/registerNode.ts
+++ b/src/lib/registerNode.ts
@@ -1,0 +1,31 @@
+import * as RED from 'node-red';
+import * as REDRegistry from '@node-red/registry';
+import { TechnicalNode } from './TechnicalNode';
+
+export function registerNode<
+    TNode extends REDRegistry.Node<TCredentials> = any,
+    TNodeDefinition extends REDRegistry.NodeDef = any,
+    TCredentials = any,
+    TSettings = any
+>(
+    nodeRED: RED.NodeAPI,
+    type: string,
+    nodeConstructor: new (nodeRED: RED.NodeAPI) => TechnicalNode<TNode, TNodeDefinition, TCredentials>,
+    opts?: {
+        credentials?: REDRegistry.NodeCredentials<TCredentials>;
+        settings?: REDRegistry.NodeSettings<TSettings>; // tslint:disable-line:no-unnecessary-generics
+    }
+) {
+    nodeRED.nodes.registerType(
+        type,
+        function (this: TNode, definition: TNodeDefinition) {
+            try {
+                const node = new nodeConstructor(nodeRED);
+                node.nodeConstructor(this, definition);
+            } catch (e) {
+                this.error(e);
+            }
+        },
+        opts
+    );
+}

--- a/src/nodes/Controller.ts
+++ b/src/nodes/Controller.ts
@@ -1,47 +1,40 @@
 import { NodeAPI } from 'node-red';
 import { TechnicalNode } from '../lib/TechnicalNode';
-import * as REDRegistry from '@node-red/registry';
 import Controller from 'unifi-client';
 import { TControllerNode } from '../types/TControllerNode';
 import { TControllerCredentials } from '../types/TControllerCredentials';
+import { registerNode } from '../lib/registerNode';
 
 class ControllerNode extends TechnicalNode<TControllerNode, any, TControllerCredentials> {
-    init(
-        type: string,
-        construct?: (node: any, definition: any) => void,
-        opts?: { credentials?: REDRegistry.NodeCredentials<any>; settings?: REDRegistry.NodeSettings<any> }
-    ) {
-        super.init(type, construct, opts, () => {
-            this.node.controller = new Controller({
-                username: this.node.credentials.username,
-                password: this.node.credentials.password,
-                url: this.definition.url,
-                strictSSL: this.definition.strictSSL
-            });
+    protected async init(): Promise<void> {
+        await super.init();
+        this.node.controller = new Controller({
+            username: this.node.credentials.username,
+            password: this.node.credentials.password,
+            url: this.definition.url,
+            strictSSL: this.definition.strictSSL
+        });
 
-            this.node.on('close', async (removed: boolean, done: () => void) => {
-                try {
-                    if (removed) {
-                        // This node has been disabled/deleted
-                        // try to logout
-                        // @ts-ignore (logged not public for the moment)
-                        if (this.node.controller?.logged) {
-                            await this.node.controller.logout();
-                        }
+        this.node.on('close', async (removed: boolean, done: () => void) => {
+            try {
+                if (removed) {
+                    // This node has been disabled/deleted
+                    // try to logout
+                    if (this.node.controller.logged) {
+                        await this.node.controller.logout();
                     }
-                } catch (e: any) {
-                    this.node.error(e.message);
-                } finally {
-                    done();
                 }
-            });
+            } catch (e: any) {
+                this.node.error(e.message);
+            } finally {
+                done();
+            }
         });
     }
 }
 
 module.exports = (RED: NodeAPI) => {
-    const node = new ControllerNode(RED);
-    node.init('unifi-controller', undefined, {
+    registerNode(RED, 'unifi-controller', ControllerNode, {
         credentials: {
             username: { type: 'text' },
             password: { type: 'password' }

--- a/src/nodes/DoorEvents.ts
+++ b/src/nodes/DoorEvents.ts
@@ -6,27 +6,25 @@ import { TDoorEventsNodeConfig } from '../types/TDoorEventsNodeConfig';
 import { TDoorEventsMsg } from '../types/TDoorEventsMsg';
 import { EProxyNamespaces } from 'unifi-client';
 import { TSendMessage } from '../types/TSendMessage';
+import { registerNode } from '../lib/registerNode';
 
 class DoorEventsNode extends Node<TDoorEventsNode, TDoorEventsNodeConfig> {
     private eventsUntil: number = 0;
-    init(
-        type: string,
-        construct?: (node: any, definition: any) => void,
-        opts?: { credentials?: REDRegistry.NodeCredentials<any>; settings?: REDRegistry.NodeSettings<any> }
-    ): void {
-        super.init(type, construct, opts, () => {
-            this.node.on('input', async (msg: TDoorEventsMsg, send, done) => {
-                try {
-                    if (msg.until) {
-                        this.eventsUntil = msg.until;
-                    }
 
-                    await this.poll(send);
-                } catch (e: any) {
-                    this.node.error(e);
+    protected async init(): Promise<void> {
+        await super.init();
+
+        this.node.on('input', async (msg: TDoorEventsMsg, send, done) => {
+            try {
+                if (msg.until) {
+                    this.eventsUntil = msg.until;
                 }
-                done();
-            });
+
+                await this.poll(send);
+            } catch (e: any) {
+                this.node.error(e);
+            }
+            done();
         });
     }
 
@@ -130,6 +128,5 @@ class DoorEventsNode extends Node<TDoorEventsNode, TDoorEventsNodeConfig> {
 }
 
 module.exports = (RED: REDRegistry.NodeAPI) => {
-    const node = new DoorEventsNode(RED);
-    node.init('unifi-door-events');
+    registerNode(RED, 'unifi-door-events', DoorEventsNode);
 };

--- a/src/nodes/GetAccessDevices.ts
+++ b/src/nodes/GetAccessDevices.ts
@@ -1,0 +1,135 @@
+import { Node } from '../lib/Node';
+import * as REDRegistry from '@node-red/registry';
+import { ENodeStatus } from '../lib/ENodeStatus';
+import { EProxyNamespaces } from 'unifi-client';
+import { TSendMessage } from '../types/TSendMessage';
+import { TGetAccessDevicesNode } from '../types/TGetAccessDevicesNode';
+import { TGetAccessDevicesNodeConfig } from '../types/TGetAccessDevicesNodeConfig';
+import { registerNode } from '../lib/registerNode';
+
+export interface TopoCommons {
+    unique_id: string;
+    name: string;
+    up_id: string;
+    timezone: string;
+    location_type: string;
+    extra_type: string;
+    full_name: string;
+    level: number;
+    work_time: string;
+    work_time_id: string;
+    extras: Record<string, string>;
+}
+
+export interface Topology extends TopoCommons {
+    floors: Array<Floor>;
+}
+
+export interface Floor extends TopoCommons {
+    doors: Array<Door>;
+}
+
+export interface Door extends TopoCommons {
+    device_groups?: Array<Array<DeviceGroup>>;
+    hotel_devices?: Array<any>;
+}
+
+export interface DeviceGroup {
+    unique_id: string;
+    name: string;
+    device_type: string;
+    connected_uah_id: string;
+    location_id: string;
+    firmware: string;
+    version: string;
+    ip: string;
+    mac: string;
+    hw_type: string;
+    start_time: number;
+    security_check: boolean;
+    resource_name: string;
+    revision: string;
+    revision_update_time: number;
+    version_update_time: number;
+    firmware_update_time: number;
+    adopt_time: number;
+    location: Door;
+    configs: Array<Config>;
+    is_connected: boolean;
+    is_online: boolean;
+    is_revision_up_to_date: boolean;
+    is_adopted: boolean;
+    is_managed: boolean;
+    update: null;
+    capabilities: Array<string>;
+}
+
+export interface Config {
+    device_id: string;
+    key: string;
+    value: string;
+    tag: string;
+}
+
+class GetAccessDevicesNode extends Node<TGetAccessDevicesNode, TGetAccessDevicesNodeConfig> {
+    protected async init(): Promise<void> {
+        await super.init();
+        this.node.on('input', async (_msg, send, done) => {
+            try {
+                await this.getDevices(send);
+            } catch (e: any) {
+                this.node.error(e);
+            }
+            done();
+        });
+    }
+
+    private async getDevices(sendFn?: (msg: TSendMessage) => void) {
+        try {
+            this.setStatus(ENodeStatus.PENDING, 'send request');
+
+            try {
+                //better way to do this ?
+                const res = await this.controller.getInstance().get<{
+                    code: number;
+                    msg: string;
+                    data: Array<Topology>;
+                }>('/devices/topology', {
+                    apiVersion: 2,
+                    proxyNamespace: EProxyNamespaces.ACCESS
+                });
+
+                //get events from request
+                const topologies = res.data.data;
+
+                const devices = topologies
+                    .map((topologie) => topologie.floors.map((floor) => floor.doors.map((door) => door.device_groups)))
+                    .flat(4)
+                    //remove undefined results
+                    .filter((d) => !!d) as Array<DeviceGroup>;
+
+                devices.forEach((d) => {
+                    this.send(
+                        {
+                            payload: {
+                                device: d
+                            }
+                        },
+                        sendFn
+                    );
+                });
+
+                this.setStatus(ENodeStatus.READY, 'done');
+            } catch (e: any) {
+                this.node.error(e);
+                this.setStatus(ENodeStatus.ERROR, `fail to list access devices : ${e.message}`);
+            }
+        } catch (e: any) {
+            this.node.error(e);
+        }
+    }
+}
+
+module.exports = (RED: REDRegistry.NodeAPI) => {
+    registerNode(RED, 'unifi-get-access-devices', GetAccessDevicesNode);
+};

--- a/src/nodes/RawControllerRequest.ts
+++ b/src/nodes/RawControllerRequest.ts
@@ -1,114 +1,108 @@
 import { NodeAPI } from 'node-red';
 import { Node } from '../lib/Node';
-import * as REDRegistry from '@node-red/registry';
 import { TRawControllerRequestNode } from '../types/TRawControllerRequestNode';
 import { TRawControllerRequestNodeMsg } from '../types/TRawControllerRequestNodeMsg';
 import { EProxyNamespaces } from 'unifi-client';
 import { Method } from 'axios';
 import { ENodeStatus } from '../lib/ENodeStatus';
+import { registerNode } from '../lib/registerNode';
 
 class RawControllerRequestNode extends Node<TRawControllerRequestNode> {
-    init(
-        type: string,
-        construct?: (node: any, definition: any) => void,
-        opts?: { credentials?: REDRegistry.NodeCredentials<any>; settings?: REDRegistry.NodeSettings<any> }
-    ) {
-        super.init(type, construct, opts, async () => {
-            this.node.on('input', async (msg: TRawControllerRequestNodeMsg, send, done) => {
-                try {
-                    let method: Method = 'get';
-                    if (
-                        msg.method &&
-                        ['get', 'delete', 'head', 'options', 'post', 'put', 'patch', 'purge', 'link', 'unlink'].includes(
-                            msg.method?.toLowerCase()
-                        )
-                    ) {
-                        method = msg.method?.toLowerCase() as Method;
-                    } else if (msg.method) {
-                        this.setStatus(ENodeStatus.ERROR, `unknown method "${msg.method}"`);
-                    }
-
-                    let url = '/';
-                    if (msg.url) {
-                        url = msg.url;
-                    }
-
-                    let proxyNamespace = undefined;
-                    if (msg.proxyNamespace && Object.values(EProxyNamespaces)?.includes(msg.proxyNamespace)) {
-                        proxyNamespace = msg.proxyNamespace;
-                    } else if (msg.proxyNamespace) {
-                        this.setStatus(ENodeStatus.ERROR, `unknown namespace "${msg.proxyNamespace}"`);
-                    }
-
-                    let data;
-                    if (msg.data) {
-                        data = msg.data;
-                    }
-
-                    let params;
-                    if (msg.params) {
-                        params = msg.params;
-                    }
-
-                    let urlParams;
-                    if (msg.urlParams) {
-                        urlParams = msg.urlParams;
-                    }
-
-                    let site;
-                    if (msg.site) {
-                        site = msg.site;
-                    }
-                    let apiVersion;
-                    if (msg.apiVersion) {
-                        apiVersion = msg.apiVersion;
-                    }
-
-                    const res = (
-                        await this.controller.getInstance().request({
-                            url,
-                            method,
-                            proxyNamespace,
-                            data,
-                            params,
-                            urlParams,
-                            site,
-                            apiVersion
-                        })
-                    ).data;
-
-                    this.send(
-                        {
-                            ...msg,
-                            payload: {
-                                data: res
-                            }
-                        },
-                        send
-                    );
-                } catch (e: any) {
-                    this.node.error(e);
-                    this.send(
-                        {
-                            ...msg,
-                            payload: {
-                                error: {
-                                    message: e.message,
-                                    stack: e.stack,
-                                    code: e.code
-                                }
-                            }
-                        },
-                        send
-                    );
+    protected async init(): Promise<void> {
+        await super.init();
+        this.node.on('input', async (msg: TRawControllerRequestNodeMsg, send, done) => {
+            try {
+                let method: Method = 'get';
+                if (
+                    msg.method &&
+                    ['get', 'delete', 'head', 'options', 'post', 'put', 'patch', 'purge', 'link', 'unlink'].includes(
+                        msg.method?.toLowerCase()
+                    )
+                ) {
+                    method = msg.method?.toLowerCase() as Method;
+                } else if (msg.method) {
+                    this.setStatus(ENodeStatus.ERROR, `unknown method "${msg.method}"`);
                 }
-                done();
-            });
+
+                let url = '/';
+                if (msg.url) {
+                    url = msg.url;
+                }
+
+                let proxyNamespace = undefined;
+                if (msg.proxyNamespace && Object.values(EProxyNamespaces)?.includes(msg.proxyNamespace)) {
+                    proxyNamespace = msg.proxyNamespace;
+                } else if (msg.proxyNamespace) {
+                    this.setStatus(ENodeStatus.ERROR, `unknown namespace "${msg.proxyNamespace}"`);
+                }
+
+                let data;
+                if (msg.data) {
+                    data = msg.data;
+                }
+
+                let params;
+                if (msg.params) {
+                    params = msg.params;
+                }
+
+                let urlParams;
+                if (msg.urlParams) {
+                    urlParams = msg.urlParams;
+                }
+
+                let site;
+                if (msg.site) {
+                    site = msg.site;
+                }
+                let apiVersion;
+                if (msg.apiVersion) {
+                    apiVersion = msg.apiVersion;
+                }
+
+                const res = (
+                    await this.controller.getInstance().request({
+                        url,
+                        method,
+                        proxyNamespace,
+                        data,
+                        params,
+                        urlParams,
+                        site,
+                        apiVersion
+                    })
+                ).data;
+
+                this.send(
+                    {
+                        ...msg,
+                        payload: {
+                            data: res
+                        }
+                    },
+                    send
+                );
+            } catch (e: any) {
+                this.node.error(e);
+                this.send(
+                    {
+                        ...msg,
+                        payload: {
+                            error: {
+                                message: e.message,
+                                stack: e.stack,
+                                code: e.code
+                            }
+                        }
+                    },
+                    send
+                );
+            }
+            done();
         });
     }
 }
 
 module.exports = (RED: NodeAPI) => {
-    const node = new RawControllerRequestNode(RED);
-    node.init('unifi-raw-controller-request');
+    registerNode(RED, 'unifi-raw-controller-request', RawControllerRequestNode);
 };

--- a/src/nodes/UnlockRelais.ts
+++ b/src/nodes/UnlockRelais.ts
@@ -1,0 +1,68 @@
+import { Node } from '../lib/Node';
+import * as REDRegistry from '@node-red/registry';
+import { ENodeStatus } from '../lib/ENodeStatus';
+import { EProxyNamespaces } from 'unifi-client';
+import { TUnlockRelaisMsg } from '../types/TUnlockRelaisMsg';
+import { TUnlockRelaisNode } from '../types/TUnlockRelaisNode';
+import { TUnlockRelaisNodeConfig } from '../types/TUnlockRelaisNodeConfig';
+import { registerNode } from '../lib/registerNode';
+
+class UnlockRelaisNode extends Node<TUnlockRelaisNode, TUnlockRelaisNodeConfig> {
+    private deviceId: string = '';
+    protected async init(): Promise<void> {
+        await super.init();
+        if (this.definition.deviceId) {
+            this.deviceId = this.definition.deviceId;
+        }
+
+        this.node.on('input', async (msg: TUnlockRelaisMsg, _send, done) => {
+            try {
+                let deviceId = this.deviceId;
+                if (msg.deviceId) {
+                    deviceId = msg.deviceId;
+                }
+
+                await this.unlockRelais(deviceId);
+            } catch (e: any) {
+                this.node.error(e);
+            }
+            done();
+        });
+    }
+
+    private async unlockRelais(deviceId?: string) {
+        try {
+            this.setStatus(ENodeStatus.PENDING, 'send request');
+
+            try {
+                const res = await this.controller.getInstance().put<{
+                    code: number;
+                    msg: string;
+                    data: string;
+                }>('/device/:device/relay_unlock', undefined, {
+                    apiVersion: 2,
+                    proxyNamespace: EProxyNamespaces.ACCESS,
+                    urlParams: {
+                        device: deviceId ?? this.deviceId
+                    }
+                });
+
+                if (res.data.msg === 'success') {
+                    this.setStatus(ENodeStatus.READY, 'done');
+                } else {
+                    this.setStatus(ENodeStatus.ERROR, 'something seems wrong');
+                    this.node.error(res.data);
+                }
+            } catch (e: any) {
+                this.node.error(e);
+                this.setStatus(ENodeStatus.ERROR, `fail to unlock relais "${deviceId ?? this.deviceId}" : ${e.message}`);
+            }
+        } catch (e: any) {
+            this.node.error(e);
+        }
+    }
+}
+
+module.exports = (RED: REDRegistry.NodeAPI) => {
+    registerNode(RED, 'unifi-access-unlock-relais', UnlockRelaisNode);
+};

--- a/src/types/TDoorEventsMsg.ts
+++ b/src/types/TDoorEventsMsg.ts
@@ -1,8 +1,6 @@
 import * as RED from 'node-red';
-import { TDoorEventsNodeConfig } from './TDoorEventsNodeConfig';
 
 export type TDoorEventsMsg = RED.NodeMessageInFlow &
-    Partial<TDoorEventsNodeConfig> &
     Partial<{
         until: number;
     }>;

--- a/src/types/TDoorEventsNodeConfig.ts
+++ b/src/types/TDoorEventsNodeConfig.ts
@@ -1,6 +1,3 @@
 import { TNodeConfig } from './TNodeConfig';
 
-export type TDoorEventsNodeConfig = TNodeConfig & {
-    pollInterval: number;
-    polling: boolean;
-};
+export type TDoorEventsNodeConfig = TNodeConfig;

--- a/src/types/TGetAccessDevicesNode.ts
+++ b/src/types/TGetAccessDevicesNode.ts
@@ -1,0 +1,3 @@
+import * as RED from 'node-red';
+
+export type TGetAccessDevicesNode = RED.Node;

--- a/src/types/TGetAccessDevicesNodeConfig.ts
+++ b/src/types/TGetAccessDevicesNodeConfig.ts
@@ -1,0 +1,3 @@
+import { TNodeConfig } from './TNodeConfig';
+
+export type TGetAccessDevicesNodeConfig = TNodeConfig;

--- a/src/types/TUnlockRelaisMsg.ts
+++ b/src/types/TUnlockRelaisMsg.ts
@@ -1,0 +1,6 @@
+import * as RED from 'node-red';
+
+export type TUnlockRelaisMsg = RED.NodeMessageInFlow &
+    Partial<{
+        deviceId: string;
+    }>;

--- a/src/types/TUnlockRelaisNode.ts
+++ b/src/types/TUnlockRelaisNode.ts
@@ -1,0 +1,3 @@
+import * as RED from 'node-red';
+
+export type TUnlockRelaisNode = RED.Node;

--- a/src/types/TUnlockRelaisNodeConfig.ts
+++ b/src/types/TUnlockRelaisNodeConfig.ts
@@ -1,0 +1,5 @@
+import { TNodeConfig } from './TNodeConfig';
+
+export type TUnlockRelaisNodeConfig = TNodeConfig & {
+    deviceId: string;
+};


### PR DESCRIPTION
This PR Will : 
 - fix a bug when adding multiple times the same kind of nodes
 - AccessDoor stop to autopoll . Use an injector with a repeat option instead
 - adding nodes : 
   - unifi-get-access-devices : allow you to list access devices, and get internal_id to unlock it
   - unifi-access-unlock-relais : allow you to unlock a relais by it's internal_id
 - Improve readme